### PR TITLE
refactor: listenerProvider now registers targets

### DIFF
--- a/src/keycloak-cluster/keycloak-cluster.ts
+++ b/src/keycloak-cluster/keycloak-cluster.ts
@@ -192,7 +192,6 @@ export class KeycloakCluster extends cdk.Construct {
       protocol: elbv2.ApplicationProtocol.HTTP,
       port: 8080,
       slowStart: cdk.Duration.seconds(60),
-      deregistrationDelay: cdk.Duration.seconds(60),
     });
 
     // Configure the health check for the given target group

--- a/src/keycloak-cluster/keycloak-cluster.ts
+++ b/src/keycloak-cluster/keycloak-cluster.ts
@@ -139,7 +139,6 @@ export class KeycloakCluster extends cdk.Construct {
     const { cloudMapNamespace } = iCloudMapNamespaceInfoProvider._bind(this, vpc);
 
     const listenerProvider = props?.listenerProvider ?? ListenerProvider.http();
-    const listenerInfo = listenerProvider._bind(this, vpc);
 
     // Create a keycloak task definition. The task will create a database for
     // you if the database doesn't already exist.
@@ -175,15 +174,6 @@ export class KeycloakCluster extends cdk.Construct {
       },
     });
 
-    this.targetGroup = listenerInfo.listener.addTargets('Keycloak', {
-      targets: [this.service],
-      slowStart: cdk.Duration.seconds(60),
-      port: 8080,
-      protocol: elbv2.ApplicationProtocol.HTTP,
-      conditions: listenerInfo.conditions,
-      priority: listenerInfo.priority,
-    });
-
     if (databaseInfo.connectable) {
       // Allow keycloak to connect to the database.
       databaseInfo.connectable.connections.allowDefaultPortFrom(this.service);
@@ -191,10 +181,21 @@ export class KeycloakCluster extends cdk.Construct {
 
     // Inform keycloak to use cloudmap service discovery
     keycloakTaskDefinition.useCloudMapService(this.service.cloudMapService!);
-    // Configure the health check for the given target group
-    keycloakTaskDefinition.configureHealthCheck(this.targetGroup);
 
     // Allow keycloak to connect to cluster members
     this.service.connections.allowInternally(ec2.Port.allTraffic());
+
+    // Register the service's web port with target groups
+    this.targetGroup = listenerProvider._registerTargets(this, {
+      vpc,
+      targets: [this.service],
+      protocol: elbv2.ApplicationProtocol.HTTP,
+      port: 8080,
+      slowStart: cdk.Duration.seconds(60),
+      deregistrationDelay: cdk.Duration.seconds(60),
+    });
+
+    // Configure the health check for the given target group
+    keycloakTaskDefinition.configureHealthCheck(this.targetGroup);
   }
 }

--- a/src/keycloak-cluster/keycloak-cluster.ts
+++ b/src/keycloak-cluster/keycloak-cluster.ts
@@ -186,7 +186,7 @@ export class KeycloakCluster extends cdk.Construct {
     this.service.connections.allowInternally(ec2.Port.allTraffic());
 
     // Register the service's web port with target groups
-    this.targetGroup = listenerProvider._registerTargets(this, {
+    this.targetGroup = listenerProvider._addTargets(this, {
       vpc,
       targets: [this.service],
       protocol: elbv2.ApplicationProtocol.HTTP,

--- a/src/keycloak-cluster/listener-provider.ts
+++ b/src/keycloak-cluster/listener-provider.ts
@@ -20,7 +20,6 @@ export interface IListenerInfoProvider {
  */
 export interface ListenerInfoProviderBindingProps extends elbv2.AddApplicationTargetsProps {
   readonly vpc: ec2.IVpc;
-  // readonly targetGroup: elbv2.ApplicationTargetGroup;
 }
 
 /**
@@ -87,7 +86,6 @@ export class HttpListenerProvider implements IListenerInfoProvider {
 
     const listener = loadBalancer.addListener('HTTP', {
       protocol: elbv2.ApplicationProtocol.HTTP,
-      // defaultAction: elbv2.ListenerAction.forward([props.targetGroup]),
     });
 
     return listener.addTargets('Keycloak', {

--- a/src/keycloak-cluster/listener-provider.ts
+++ b/src/keycloak-cluster/listener-provider.ts
@@ -12,7 +12,7 @@ export interface IListenerInfoProvider {
    * VPC is available.
    * @internal
    */
-  _registerTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps): elbv2.ApplicationTargetGroup;
+  _addTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps): elbv2.ApplicationTargetGroup;
 }
 
 /**
@@ -40,7 +40,7 @@ export abstract class ListenerProvider {
    */
   static fromListenerInfo(listenerInfo: ListenerInfo): IListenerInfoProvider {
     return {
-      _registerTargets: (_scope, props) => {
+      _addTargets: (_scope, props) => {
         return listenerInfo.listener.addTargets('Keycloak', {
           ...props,
           conditions: listenerInfo.conditions,
@@ -72,7 +72,7 @@ export class HttpListenerProvider implements IListenerInfoProvider {
   /**
    * @internal
    */
-  public _registerTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps) {
+  public _addTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps) {
     const loadBalancer = new elbv2.ApplicationLoadBalancer(scope, 'LoadBalancer', {
       vpc: props.vpc,
       internetFacing: true,
@@ -118,7 +118,7 @@ export class HttpsListenerProvider implements IListenerInfoProvider {
   /**
    * @internal
    */
-  _registerTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps) {
+  _addTargets(scope: cdk.Construct, props: ListenerInfoProviderBindingProps) {
     // Create a load balancer.
     const loadBalancer = new elbv2.ApplicationLoadBalancer(scope, 'LoadBalancer', {
       vpc: props.vpc,


### PR DESCRIPTION
Start moving listener logic out of the cluster construct.