### PR TITLE
fix: Database Name Environment Var

### DIFF
--- a/API.md
+++ b/API.md
@@ -1680,6 +1680,6 @@ Name | Description
 **MARIADB** |MariaDB.
 **MSSQL** |MSSQL (not yet supported, please submit a PR).
 **ORACLE** |Oracle database (not yet supported, please submit a PR).
-**POSTGRES** |Postgres (not yet supported, please submit a PR).
+**POSTGRES** |Postgres.
 
 

--- a/src/keycloak-container-extension.ts
+++ b/src/keycloak-container-extension.ts
@@ -19,7 +19,7 @@ export enum KeycloakDatabaseVendor {
   MSSQL = 'mssql',
   /** Oracle database (not yet supported, please submit a PR) */
   ORACLE = 'oracle',
-  /** Postgres (not yet supported, please submit a PR) */
+  /** Postgres */
   POSTGRES = 'postgres',
 }
 
@@ -265,7 +265,7 @@ export class KeycloakContainerExtension implements ecs.ITaskDefinitionExtension 
         KEYCLOAK_USER: this.defaultAdminUser,
         KEYCLOAK_PASSWORD: this.defaultAdminPassword,
         DB_VENDOR: this.databaseVendor,
-        DB_NAME: databaseNameForVendor,
+        DB_DATABASE: databaseNameForVendor,
         DB_SCHEMA: this._databaseSchema ?? '',
         JGROUPS_DISCOVERY_PROTOCOL: cdk.Lazy.string({
           produce: () => this._getJGroupsDiscoveryProtocol(),

--- a/test/integ/__snapshots__/snapshot.test.ts.snap
+++ b/test/integ/__snapshots__/snapshot.test.ts.snap
@@ -584,7 +584,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -1865,7 +1865,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -3121,7 +3121,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -4411,7 +4411,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -6261,7 +6261,7 @@ systemctl start amazon-ssm-agent",
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -7342,7 +7342,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -8611,7 +8611,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -9759,7 +9759,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -11011,7 +11011,7 @@ Object {
                 "Value": "postgres",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {
@@ -12267,7 +12267,7 @@ Object {
                 "Value": "mysql",
               },
               Object {
-                "Name": "DB_NAME",
+                "Name": "DB_DATABASE",
                 "Value": "keycloak",
               },
               Object {

--- a/test/keycloak-container-extension.test.ts
+++ b/test/keycloak-container-extension.test.ts
@@ -34,7 +34,7 @@ describe('KeycloakContainerExtension', () => {
       environment: expect.objectContaining({
         KEYCLOAK_USER: 'admin',
         KEYCLOAK_PASSWORD: 'admin',
-        DB_NAME: '',
+        DB_DATABASE: '',
         DB_VENDOR: 'h2',
         CACHE_OWNERS_COUNT: '1',
         CACHE_OWNERS_AUTH_SESSIONS_COUNT: '1',
@@ -256,7 +256,7 @@ describe('KeycloakContainerExtension', () => {
 
     expect(addContainerSpy).toBeCalledWith('keycloak', expect.objectContaining({
       environment: expect.objectContaining({
-        DB_NAME: 'custom',
+        DB_DATABASE: 'custom',
       }),
     }));
   });


### PR DESCRIPTION
According to https://hub.docker.com/r/jboss/keycloak/ the environment name for using a custom database name is DB_DATABASE.

DB_NAME is not working.

Fixes #